### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,7 +22,7 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(cat version.txt)
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docs-storefrontcloud-io/v2:${{ steps.get_version.outputs.VERSION }}
           registry: registry.storefrontcloud.io

--- a/.github/workflows/deploy-preview-storefrontcloud.yml
+++ b/.github/workflows/deploy-preview-storefrontcloud.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: vsf-next-demo-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: registry.storefrontcloud.io

--- a/.github/workflows/deploy-storefrontcloud.yml
+++ b/.github/workflows/deploy-storefrontcloud.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: "12.x"
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: vsf-next-demo-storefrontcloud-io/vue-storefront:${{ github.sha }}
           registry: registry.storefrontcloud.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore